### PR TITLE
fixed apiKey for base. verification was not working on blockscout for…

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -59,6 +59,7 @@ module.exports = {
   etherscan: {
     apiKey: {
       optimism: process.env.OP_BLOCKSCOUT_API_KEY,
+      base: process.env.BASE_BLOCKSCOUT_API_KEY,
     },
     customChains: [
       {
@@ -66,7 +67,6 @@ module.exports = {
         chainId: 84532,
         urls: {
           apiURL: 'https://base-sepolia.blockscout.com/api',
-          apiKey: process.env.BASE_BLOCKSCOUT_API_KEY,
           browserURL: 'https://base-sepolia.blockscout.com',
         },
       },
@@ -75,7 +75,6 @@ module.exports = {
         chainId: 11155420,
         urls: {
           apiURL: 'https://optimism-sepolia.blockscout.com/api',
-          apiKey: process.env.OP_BLOCKSCOUT_API_KEY,
           browserURL: 'https://optimism-sepolia.blockscout.com',
         },
       },


### PR DESCRIPTION
**Base Verification Fix**: 

Verifications were not working on base. I moved out `apikey` from `etherscan.customChains` and put it in `etherscan.apiKey` per the Hardhat docs. 

[Hardhat Docs Section](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#adding-support-for-other-networks) (screenshot below)

![image](https://github.com/user-attachments/assets/8701411c-09cd-4ede-a2d6-3cfca1764360)


